### PR TITLE
Add readme file for additional typingDNA configs of IS 5.11.0

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,10 +1,13 @@
 # Configuring TypingDNA with WSO2 Identity Server
 
-To use TypingDNA with WSO2 Identity Server, first you need to configure the authenticator with WSO2 Identity Server. The following topics provide instructions on how to configure the TypingDNA with WSO2 Identity Server as a risk-based authentication (RBA) option:
+To use TypingDNA with WSO2 Identity Server, first you need to configure the authenticator with WSO2 Identity Server. 
 
 ```
-Note: TypingDNA is supported with WSO2 Identity Server 6.0.0-m1 version onwards.
+Note: TypingDNA is supported with WSO2 Identity Server 5.11.0 version onwards.
 ```
+Few additional configs are needed for IS 5.11.0 which are found in [configs for IS 5.11.0](config_IS5.11.0.md).
+
+The following topics provide instructions on how to configure the TypingDNA with WSO2 Identity Server as a risk-based authentication (RBA) option:
 * [Deploying TypingDNA Artifacts](#deploying-typingdna-artifacts)
 * [Enabling TypingDNA in the WSO2 Identity Server](#enabling-typingdna-in-the-wso2-identity-server)
 * [Setting up the TypingDNA account](#setting-up-the-typingdna-account)

--- a/docs/config_IS5.11.0.md
+++ b/docs/config_IS5.11.0.md
@@ -1,25 +1,14 @@
 # Additional configurations to integrate TypingDNA with WSO2 Identity Server 5.11.0
 
-1. (If pattern deletion required) Add the following configs to the deployment.toml to enable access to the typingdna functions api.
-    ```
-    [[resource.access_control]]
-    context = "(.)/api/identity/typingdna/v1.0/(.)"
-    secure = "true"
-    http_method = "DELETE"
-    permissions=["none"]
-    scopes=["internal_login"]
-    
-    [tenant_context.rewrite]
-    custom_webapps=["/api/identity/typingdna/v1.0/"]
-    ```
-2. Add the following line to basicauth.jsp in authenticationendpoint webapp after the list of page imports
+
+1. Add the following line to basicauth.jsp in authenticationendpoint webapp after the list of page imports
     ```
     <jsp:directive.include file="plugins/typing-dna.jsp"/>
     ```
-3. Copy https://github.com/wso2/identity-apps/blob/master/apps/authentication-portal/src/main/webapp/plugins/typing-dna.jsp to `authenticationendpoint/plugins` directory.
+2. Copy https://github.com/wso2/identity-apps/blob/master/apps/authentication-portal/src/main/webapp/plugins/typing-dna.jsp to `authenticationendpoint/plugins` directory.
 
 
-5. In the `typing-dna.jsp` file change the element id `username` to `usernameUserInput` in lines 32 and 37.
+3. In the `typing-dna.jsp` file change the element id `username` to `usernameUserInput` in lines 32 and 37.
 
 
-6. (Optional) Copy https://github.com/wso2/identity-apps/blob/master/apps/authentication-portal/src/main/webapp/js/typingdna.js to `authenticationendpoint/js` directory. This can help reduce load time of the auth endpoint.
+4. (Optional) Copy https://github.com/wso2/identity-apps/blob/master/apps/authentication-portal/src/main/webapp/js/typingdna.js to `authenticationendpoint/js` directory. This can help reduce load time of the auth endpoint.

--- a/docs/config_IS5.11.0.md
+++ b/docs/config_IS5.11.0.md
@@ -1,0 +1,25 @@
+# Additional configurations to integrate TypingDNA with WSO2 Identity Server 5.11.0
+
+1. (If pattern deletion required) Add the following configs to the deployment.toml to enable access to the typingdna functions api.
+    ```
+    [[resource.access_control]]
+    context = "(.)/api/identity/typingdna/v1.0/(.)"
+    secure = "true"
+    http_method = "DELETE"
+    permissions=["none"]
+    scopes=["internal_login"]
+    
+    [tenant_context.rewrite]
+    custom_webapps=["/api/identity/typingdna/v1.0/"]
+    ```
+2. Add the following line to basicauth.jsp in authenticationendpoint webapp after the list of page imports
+    ```
+    <jsp:directive.include file="plugins/typing-dna.jsp"/>
+    ```
+3. Copy https://github.com/wso2/identity-apps/blob/master/apps/authentication-portal/src/main/webapp/plugins/typing-dna.jsp to `authenticationendpoint/plugins` directory.
+
+
+5. In the `typing-dna.jsp` file change the element id `username` to `usernameUserInput` in lines 32 and 37.
+
+
+6. (Optional) Copy https://github.com/wso2/identity-apps/blob/master/apps/authentication-portal/src/main/webapp/js/typingdna.js to `authenticationendpoint/js` directory. This can help reduce load time of the auth endpoint.


### PR DESCRIPTION
Few additional configs are required to enable TypingDNA integration with IS 5.11.0. Those are included in a separate readme file which is linked from the main readme file. This readme file can be removed once a new 5.11.0 version is released with these configs patched.